### PR TITLE
doc: fix typo in upgrade heading (Upgrad -> Upgrade)

### DIFF
--- a/en/maintain/upgrade.md
+++ b/en/maintain/upgrade.md
@@ -1,4 +1,4 @@
-# Upgrad Cloudreve {#upgrade-cloudreve}
+# Upgrade Cloudreve {#upgrade-cloudreve}
 
 The steps described in this section only apply to upgrading within V4.x.x versions.
 


### PR DESCRIPTION
The H1 heading on the [Upgrade Cloudreve](https://docs.cloudreve.org/en/maintain/upgrade) page reads `# Upgrad Cloudreve`, missing the trailing `e`.

This fixes it to `# Upgrade Cloudreve`, which also matches the existing anchor `{#upgrade-cloudreve}`.